### PR TITLE
ログイン機能の実装中

### DIFF
--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users
+      get 'profile', to: 'users#show'
+      get '/edit/profile', to: 'users#edit'
       get 'sign_up', to: 'users#new'
 
       post 'login', to: 'sessions#login'

--- a/frontend/src/components/layouts/Menu.js
+++ b/frontend/src/components/layouts/Menu.js
@@ -5,7 +5,7 @@ import { useLoggedInStatusContext } from "../../contexts/LoginContext";
 export const Menu = () => {
 
   const baseURL = "http://localhost:3000";
-  const { user, Logout, loggedInStatus, logged_in } = useLoggedInStatusContext();
+  const { user, Logout, logged_in } = useLoggedInStatusContext();
 
   const LoginAndLogoutBox = () => {
     if (logged_in === true) {
@@ -19,6 +19,7 @@ export const Menu = () => {
             </div>
           </Link>
           <p className="btn red-btn" onClick={Logout}>ログアウト</p>
+          <p>ログイン状態：ログイン中</p>
         </>
       )
     } else {
@@ -27,6 +28,7 @@ export const Menu = () => {
         <>
           <Link to="users/sign_up">ユーザー新規登録</Link>
           <Link className="btn blue-btn" to="login">ログイン</Link>
+          <p>ログイン状態：未ログイン</p>
         </>
       );
     }
@@ -38,7 +40,6 @@ export const Menu = () => {
       <Link to="/">HOME</Link>
       <br />
       {LoginAndLogoutBox()}
-      {`ログイン状態: ${loggedInStatus}`}
     </div>
   );
 }

--- a/frontend/src/components/pages/users/UserProfile.js
+++ b/frontend/src/components/pages/users/UserProfile.js
@@ -30,7 +30,7 @@ export const UserProfile = () => {
   return(
     <div>
       <h2>「{user.name}」の編集画面</h2>
-      <img src={`${baseURL}/uploads/user/image/${userId}/icon.jpg`} className="user-icon" alt="" />
+      <img src={`${baseURL}/uploads/user/image/${user.id}/icon.jpg`} className="user-icon" alt="" />
       <p>名前：{user.name}</p>
       <p>性別：{userSex()}</p>
       <p>誕生日：{user.birthday}</p>


### PR DESCRIPTION
ログイン機能でリロードをしてもstateを保持できるように改善しました。
引き続き以下の問題を解消し、本イシューをクローズします。

・カレントユーザー以外のプロフィール情報を見れないように実装する。
・カレントユーザーのアイコンを更新した際、リロードしなければアイコン画像が更新されない不具合を解消する
・ユーザー情報を更新した後、ログインできなくなる致命的なバグを解消する。